### PR TITLE
Reverted back to previous state. Actually did not need the port mappi…

### DIFF
--- a/FitskedApp/Program.cs
+++ b/FitskedApp/Program.cs
@@ -130,11 +130,6 @@ else
     app.UseHsts();
 }
 
-// IMPORTANT: Below needs to be taken out immediately after deployment, just to see if this fixes the binding problem.
-//var port = Environment.GetEnvironmentVariable("PORT") ?? "8080"; // Default to 8080 if PORT is not set
-//app.Urls.Add($"http://0.0.0.0:{port}");
-// IMPORTANT
-
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();

--- a/task-definition.json
+++ b/task-definition.json
@@ -149,7 +149,7 @@
     ],
     "taskRoleArn": "arn:aws:iam::448049819404:role/ecsTaskExecutionRole",
     "executionRoleArn": "arn:aws:iam::448049819404:role/ecsTaskExecutionRole",
-    "networkMode": "host",
+    "networkMode": "awsvpc",
     "volumes": [
         {
             "name": "sql_server",


### PR DESCRIPTION
…ng specified in the program.cs. We are already allowing the internet to access the instance through what we've done in aws. Also changed networking mode back to awsvpc.